### PR TITLE
feat: Implement deep linking and notification for images

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <application
         android:name=".PinterestDemoApp"
         android:allowBackup="true"
@@ -18,6 +20,12 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="myapp" android:host="detail" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/com/vsay/pintereststylegriddemo/common/notification/NotificationHelper.kt
+++ b/app/src/main/java/com/vsay/pintereststylegriddemo/common/notification/NotificationHelper.kt
@@ -1,0 +1,106 @@
+package com.vsay.pintereststylegriddemo.common.notification
+
+import android.annotation.SuppressLint
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.vsay.pintereststylegriddemo.R
+
+object NotificationHelper {
+    private const val CHANNEL_ID =
+        "demo_channel" // Consider making this more specific if you have multiple channels
+    private const val TAG = "NotificationHelper"
+
+    /**
+     * Shows a notification that deep links to an image detail.
+     *
+     * IMPORTANT: The caller is responsible for ensuring that the POST_NOTIFICATIONS
+     * permission has been granted on Android 13 (API 33) and above before calling this method.
+     *
+     * @param context Context.
+     * @param imageId The ID of the image to link to.
+     * @param contentTitle The title for the notification.
+     * @param contentText The main text for the notification.
+     */
+    @SuppressLint("MissingPermission") // Suppressed because permission check is handled by the caller
+    fun showDeepLinkNotification(
+        context: Context,
+        imageId: String,
+        contentTitle: String,
+        contentText: String
+    ) {
+        val appContext = context.applicationContext
+
+        // Intent for the deep link
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("myapp://detail/$imageId")).apply {
+            // Add package to make it explicit if multiple apps could handle this,
+            // otherwise, rely on AndroidManifest's intent-filter.
+            // setPackage(appContext.packageName)
+        }
+
+        val pendingIntent = PendingIntent.getActivity(
+            appContext,
+            imageId.hashCode(), // Unique request code
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val builder = NotificationCompat.Builder(appContext, CHANNEL_ID)
+            // IMPORTANT: Replace with your actual small notification icon
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle(contentTitle)
+            .setContentText(contentText)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+            // .setGroup("recommended_images_group") // Optional
+
+        try {
+            with(NotificationManagerCompat.from(appContext)) {
+                notify(
+                    imageId.hashCode(),
+                    builder.build()
+                )
+            }
+        } catch (e: SecurityException) {
+            Log.e(
+                TAG,
+                "Failed to send notification. Missing POST_NOTIFICATIONS permission or other issue.",
+                e
+            )
+        }
+    }
+
+    /**
+     * Creates the notification channel for the application.
+     * Should be called once, e.g., in Application.onCreate() or MainActivity.onCreate().
+     *
+     * @param context Context.
+     */
+    fun createNotificationChannel(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val appContext = context.applicationContext
+            val name =
+                appContext.getString(R.string.notification_channel_name)
+            val descriptionText =
+                appContext.getString(R.string.notification_channel_description)
+            val importance = NotificationManager.IMPORTANCE_DEFAULT
+
+            val channel = NotificationChannel(CHANNEL_ID, name, importance).apply {
+                description = descriptionText
+            }
+
+            val notificationManager: NotificationManager =
+                appContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+}

--- a/app/src/main/java/com/vsay/pintereststylegriddemo/common/permission/PermissionHandler.kt
+++ b/app/src/main/java/com/vsay/pintereststylegriddemo/common/permission/PermissionHandler.kt
@@ -1,0 +1,111 @@
+package com.vsay.pintereststylegriddemo.common.permission
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+
+/**
+ * A state holder for managing a specific runtime permission.
+ *
+ * @property permission The Android permission string (e.g., Manifest.permission.CAMERA).
+ * @property hasPermission A mutable state indicating whether the permission is currently granted.
+ * @property requestPermission A lambda function to trigger the permission request.
+ */
+@Immutable
+data class PermissionHandlerState(
+    val permission: String,
+    val hasPermission: MutableState<Boolean>,
+    val requestPermission: () -> Unit
+)
+
+/**
+ * A Composable function that remembers and manages the state for a given runtime permission.
+ *
+ * It provides a [PermissionHandlerState] which includes the current status of the permission
+ * and a lambda to request it.
+ *
+ * @param permission The Android permission string (e.g., Manifest.permission.POST_NOTIFICATIONS).
+ * @param onPermissionGranted Optional callback invoked when the permission is granted by the user.
+ * @param onPermissionDenied Optional callback invoked when the permission is denied by the user.
+ *                           It receives a lambda function `openAppSettings` which can be called
+ *                           to navigate the user to the app's settings screen.
+ * @param requiresPermission A boolean indicating if this permission is actually required based on
+ *                           runtime conditions (e.g., SDK version). If false, `hasPermission` will
+ *                           be considered true by default.
+ * @return A [PermissionHandlerState] instance.
+ */
+@Composable
+fun rememberPermissionHandler(
+    permission: String,
+    onPermissionGranted: () -> Unit = {},
+    onPermissionDenied: (openAppSettings: () -> Unit) -> Unit = { _ -> },
+    requiresPermission: Boolean = true // By default, assume permission is required
+): PermissionHandlerState {
+    val context = LocalContext.current
+
+    val hasPermissionState = remember(permission, requiresPermission) {
+        mutableStateOf(
+            if (!requiresPermission) true
+            else ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+        )
+    }
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+        onResult = { isGranted ->
+            hasPermissionState.value = isGranted
+            if (isGranted) {
+                onPermissionGranted()
+            } else {
+                onPermissionDenied { context.launchAppSettings() }
+            }
+        }
+    )
+
+    // If permission status changes externally (e.g., user revokes in settings),
+    // this LaunchedEffect will try to update our state.
+    // Note: This isn't foolproof for all scenarios but helps for background->foreground changes.
+    LaunchedEffect(permission, context) {
+        if (requiresPermission) {
+            hasPermissionState.value = ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+        }
+    }
+
+    return remember(permission, launcher) {
+        PermissionHandlerState(
+            permission = permission,
+            hasPermission = hasPermissionState,
+            requestPermission = {
+                if (requiresPermission) {
+                    launcher.launch(permission)
+                } else {
+                    // If permission is not required (e.g., older SDK), treat as granted
+                    hasPermissionState.value = true
+                    onPermissionGranted()
+                }
+            }
+        )
+    }
+}
+
+/**
+ * Extension function on Context to launch the application's detail settings screen.
+ */
+fun Context.launchAppSettings() {
+    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+        data = Uri.fromParts("package", packageName, null)
+    }
+    startActivity(intent)
+}

--- a/app/src/main/java/com/vsay/pintereststylegriddemo/presentation/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/vsay/pintereststylegriddemo/presentation/navigation/AppNavHost.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import androidx.navigation.navDeepLink
 import com.vsay.pintereststylegriddemo.presentation.app.AppViewModel
 import com.vsay.pintereststylegriddemo.presentation.detail.ui.DetailScreen
 import com.vsay.pintereststylegriddemo.presentation.home.ui.HomeScreen
@@ -46,7 +47,8 @@ fun AppNavHost(
             arguments = listOf(navArgument(NavArgs.IMAGE_ID) {
                 type = NavType.StringType
                 // nullable = true // Consider if imageId can ever be null, though unlikely for a detail screen
-            })
+            }),
+            deepLinks = listOf(navDeepLink { uriPattern = "myapp://detail/{${NavArgs.IMAGE_ID}}" })
         ) {
             DetailScreen(
                 appViewModel = appViewModel,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,27 @@
 <resources>
+    <string name="notification_permission_rationale">Notification permission is needed to alert you about images. Please grant the permission in settings.</string>
+    <string name="button_settings">Settings</string>
+    <string name="home_screen_title">Home</string>
+    <string name="content_description_search">Search</string>
+    <string name="unknown_author">Unknown</string>
+    <string name="unknown_error">Unknown error</string>
+
     <string name="app_name">PinterestStyleGridDemo</string>
+    <string name="notification_channel_name">Image Recommendations</string>
+    <string name="notification_channel_description">Notifications for recommended images.</string>
+    <string name="notification_title_image_from">Image from %1$s</string>
+    <string name="notification_text_tap_to_view">Tap to view details for image ID: %1$s</string>
+    <string name="error_message_generic">Oops! Something went wrong:\n%1$s</string>
+    <string name="button_retry">Retry</string>
+
+    <string name="error_invalid_or_missing_image_id">Invalid or missing image ID.</string>
+    <string name="details_screen_title">Details</string>
+    <string name="image_data_not_available">Image data not available.</string>
+    <string name="content_description_image_by_author">Image by %1$s</string>
+    <string name="label_id">ID</string>
+    <string name="label_author">Author</string>
+    <string name="label_width">Width</string>
+    <string name="label_height">Height</string>
+    <string name="label_pixels_value">%1$d px</string>
+    <string name="label_download_url">Download URL</string>
 </resources>


### PR DESCRIPTION
- Added `NotificationHelper` to create and display notifications.
- Implemented deep linking to `DetailScreen` via notifications using `myapp://detail/{imageId}` URI.
- Added `POST_NOTIFICATIONS` permission to `AndroidManifest.xml` and an intent filter for the deep link.
- Created `PermissionHandler` composable to manage runtime permissions, specifically for notifications on Android 13+.
- Integrated notification permission request flow in `HomeScreen`:
    - On long-pressing an image, a notification is shown if permission is granted.
    - If permission is not granted, it's requested. A snackbar with a settings link is shown if denied.
- `HomeScreen`:
    - Created notification channel on launch.
    - Modified `ImageCardM3` to handle `onClick` and `onLongClick`.
    - Localized UI strings.
- `DetailScreen`:
    - Improved error handling for missing/invalid image IDs.
    - Localized UI strings.
    - Updated `TopAppBar` title to use string resources.
- `DetailViewModel`:
    - Injected `Application` context to access string resources for error messages.
    - Improved error message for missing image ID.
- `AppNavHost`:
    - Added `deepLinks` configuration for the `DetailScreen` route.
- Added new string resources for notifications, permissions, and UI elements.